### PR TITLE
Fixed RSS validation error

### DIFF
--- a/index.js
+++ b/index.js
@@ -15,7 +15,6 @@ module.exports = function (username, cb, rssFormat) {
         title: username + ' Twitter feed',
         description: 'A generated feed of the tweets from ' + username,
         link: url,
-        image: '???',
 
         author: {
           name: '???',


### PR DESCRIPTION
The W3C validator at https://validator.w3.org/feed/ reports that "???" isn't a valid URL; this PR fixes the error.
